### PR TITLE
Bug selected env version

### DIFF
--- a/coffee/zeno-controllers.coffee
+++ b/coffee/zeno-controllers.coffee
@@ -344,6 +344,7 @@ envCtrl = ($scope, $routeParams, $timeout, socket) ->
   $scope.thumb           = '_thumb.png'
   $scope.current         = 0
   $scope.selectedVersion = $scope.versions[$scope.versions.length - 1]
+  $scope.pdfExctrating   = false
 
   angular.forEach $scope.list.envs, (env)->
     if env.alias is $scope.title && $scope.list[$scope.device]?

--- a/views/routes/env.jade
+++ b/views/routes/env.jade
@@ -1,11 +1,9 @@
 div(class='detail', keyup="move($event)")
   div(class="detailControl")
-    div
-
     h3 {{title}}
-
     div
-      select(style='float:left', ng-options='version for version in versions.reverse()', ng-change='update()', ng-model='selectedVersion')
+      select(style='float:left', ng-change='update()', ng-model='selectedVersion')
+        option(ng-repeat='version in versions.slice().reverse()') {{version}}
       div(class="btn" style="float:left", ng-click="pdfExtraction()")
         a(style="padding: 0 5px", ng-click="pdfExctrating=true", ng-hide="pdfExctrating", href="/pdf/{{title}}/{{device}}") Pdf extract
         div(class="spinner", ng-show="pdfExctrating")


### PR DESCRIPTION
Bug in selected version when you are in env page. I think it's happened because ng-model take version not in reverse order. The bug disappear when i replace ng-options with option tag with ng-repeat.
